### PR TITLE
Fix typo

### DIFF
--- a/src/model/propertyInfo.js
+++ b/src/model/propertyInfo.js
@@ -68,7 +68,7 @@ const info = [
     variable: 'residual_sugar',
     operator: '>',
     threshold: 3.8,
-    info: ['getting on the sweater', 'side for a red wine now'],
+    info: ['getting on the sweeter', 'side for a red wine now'],
     infoColour: '#777',
   },
   {


### PR DESCRIPTION
Hey @jadiehm, just fixed up a typo I got pointed towards in that last simulator section.

Should really be "_sweeter_" rather than "_sweater_", i guess:

![image](https://user-images.githubusercontent.com/4750075/113058940-ba3b9e00-91a6-11eb-96fc-469ae2ecb4b7.png)
